### PR TITLE
ADs in a list, perms in postfix/ldap, libldap-common

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ Author Information
 
 [Pavel Milanes](https://github.com/stdevPavelmc), same author of the [MailAD](https://github.com/stdevPavelmc/mailad) mail server provision script.
 
-This Ansible role is based on a previous work done porting MailAD to Ansible by [@dienteperro](https://github.com/dienteperro), you can see his work here: [ansible-mailad](https://github.com/dienteperro/mailad-ansible)
+This Ansible role is based on a previous work done porting MailAD to Ansible by [@dienteperro](https://github.com/dienteperro), you can see his work here: [mailad-ansible](https://github.com/dienteperro/mailad-ansible)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -120,6 +120,14 @@ postfix_templates:
   - rules/disclaimer_domains
   - rules/filter_nat
   - rules/header_checks
+  
+postfix_ldap_templates:
+  - email2user.cf
+  - local_in.cf
+  - local_out.cf
+  - mailbox_maps.cf
+  - national_in.cf
+  - national_out.cf
 
 # folders
 folders_postfix:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,7 +32,6 @@ packages_base:
     - dovecot-ldap
     - dovecot-sieve
     - dovecot-managesieved
-    - ldap-utils
     - libldap-common
     - libnet-ldap-perl
     - ldap-utils

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ packages_base:
     - dovecot-ldap
     - dovecot-sieve
     - dovecot-managesieved
+    - libldap-common
     - libnet-ldap-perl
     - ldap-utils
     - rsync
@@ -31,6 +32,8 @@ packages_base:
     - dovecot-ldap
     - dovecot-sieve
     - dovecot-managesieved
+    - ldap-utils
+    - libldap-common
     - libnet-ldap-perl
     - ldap-utils
     - rsync

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -111,6 +111,10 @@
   command: /usr/sbin/postmap /etc/postfix/rules/lista_negra
   notify: Reload postfix
   changed_when: False
+  
+- name: postmap recipient_bcc
+  command: /usr/sbin/postmap /etc/postfix/recipient_bcc
+  notify: Reload postfix
 
 - name: Run mail_groups_update
   command: /etc/cron.daily/mail_groups_update

--- a/tasks/postfix.yml
+++ b/tasks/postfix.yml
@@ -1,4 +1,15 @@
 ---
+- name: Apply template to /etc/postfix/recipient_bcc
+  template:
+    src: ../templates/etc/postfix/recipient_bcc.j2
+    dest: /etc/postfix/recipient_bcc
+    owner: root
+    group: root
+    mode: '0644'
+    backup: yes
+  notify: postmap recipient_bcc
+  when: mailad_recipientbcc is defined
+
 - name: Apply template to /etc/postfix/aliases/alias_virtuales
   template:
     src: ../templates/etc/postfix/aliases/alias_virtuales.j2

--- a/tasks/postfix.yml
+++ b/tasks/postfix.yml
@@ -8,7 +8,7 @@
     mode: '0644'
     backup: yes
   notify: postmap recipient_bcc
-  when: mailad_recipientbcc is defined
+  when: recipientbcc is defined
 
 - name: Apply template to /etc/postfix/aliases/alias_virtuales
   template:

--- a/tasks/postfix.yml
+++ b/tasks/postfix.yml
@@ -44,3 +44,13 @@
     mode: '0644'
   loop: "{{ postfix_templates }}"
   notify: Postfix check
+
+- name: "Apply templates to /etc/postfix/ldap folder items"
+  template:
+    src: "../templates/etc/postfix/ldap/{{ item }}.j2"
+    dest: "/etc/postfix/ldap/{{ item }}"
+    owner: root
+    group: root
+    mode: '0640'
+  loop: "{{ postfix_ldap_templates }}"
+  notify: Postfix check

--- a/templates/etc/cron.daily/mail_groups_update.j2
+++ b/templates/etc/cron.daily/mail_groups_update.j2
@@ -14,7 +14,7 @@
 # in the system...
 
 # search opt
-SEARCH_OPTS='-o ldif-wrap=no -H "{{ ldap_uri }}" -D "{{ ldap_bind }}" -w "{{ ldap_pass }}" -b "{{ ldap_base }}"'
+SEARCH_OPTS='-o ldif-wrap=no -H "{% if ldap_host is defined %}{% for item in ldap_host %}ldaps://{{ item }}:636/{% if not loop.last %} {% endif %}{% endfor %}{% endif %}" -D "{{ ldap_bind }}" -w "{{ ldap_pass }}" -b "{{ ldap_base }}"'
 
 {% if ( everyone is defined ) and ( not everyone|bool ) %}
 # empty result: Fail

--- a/templates/etc/cron.monthly/check_maildirs.j2
+++ b/templates/etc/cron.monthly/check_maildirs.j2
@@ -20,7 +20,7 @@ function isthere () {
     # return empty string or num of entries found
 
     # LDAP query
-    ldapsearch -o ldif-wrap=no -H "{{ ldap_uri }}" -D "{{ ldap_bind }}" -w "{{ ldap_pass }}" -b "{{ ldap_base }}" "(&(objectClass=person)(sAMAccountName=${1}))" | grep "numEntries: " | awk '{print $3}'
+    ldapsearch -o ldif-wrap=no -H "{% if ldap_host is defined %}{% for item in ldap_host %}ldaps://{{ item }}:636/{% if not loop.last %} {% endif %}{% endfor %}{% endif %}" -D "{{ ldap_bind }}" -w "{{ ldap_pass }}" -b "{{ ldap_base }}" "(&(objectClass=person)(sAMAccountName=${1}))" | grep "numEntries: " | awk '{print $3}'
 }
 
 function getdetails() {

--- a/templates/etc/dovecot/dovecot-ldap.conf.ext.j2
+++ b/templates/etc/dovecot/dovecot-ldap.conf.ext.j2
@@ -21,7 +21,9 @@
 
 # LDAP URIs to use. You can use this instead of hosts list. Note that this
 # setting isn't supported by all LDAP libraries.
-uris = {{ ldap_uri }}
+{% if ldap_host is defined %}
+uris = "{% for item in ldap_host %}ldaps://{{ item }}:636/{% if not loop.last %} {% endif %}{% endfor %}"
+{% endif %}
 
 # Distinguished Name - the username used to login to the LDAP server.
 # Leave it commented out to bind anonymously (useful with auth_bind=yes).

--- a/templates/etc/postfix/ldap/email2user.cf.j2
+++ b/templates/etc/postfix/ldap/email2user.cf.j2
@@ -1,5 +1,6 @@
 # LDAP to postfix link
-server_host = {{ ldap_uri }}
+server_host = {% if ldap_host is defined %}{% for item in ldap_host %}ldaps://{{ item }}:636/{% if not loop.last %} {% endif %}{% endfor %}{% endif %}
+
 timeout = 10
 search_base = {{ ldap_base }}
 # Filter                      account active         password don't expire     password had expired

--- a/templates/etc/postfix/ldap/local_in.cf.j2
+++ b/templates/etc/postfix/ldap/local_in.cf.j2
@@ -1,5 +1,6 @@
 # LDAP to postfix link
-server_host = {{ ldap_uri }}
+server_host = {% if ldap_host is defined %}{% for item in ldap_host %}ldaps://{{ item }}:636/{% if not loop.last %} {% endif %}{% endfor %}{% endif %}
+
 timeout = 10
 search_base = {{ ldap_base }}
 query_filter = (&(mail=%u@%d)(memberOf=cn=Local_mail,ou=MAIL_ACCESS,{{ ldap_base }}))

--- a/templates/etc/postfix/ldap/local_out.cf.j2
+++ b/templates/etc/postfix/ldap/local_out.cf.j2
@@ -1,5 +1,6 @@
 # LDAP to postfix link
-server_host = {{ ldap_uri }}
+server_host = {% if ldap_host is defined %}{% for item in ldap_host %}ldaps://{{ item }}:636/{% if not loop.last %} {% endif %}{% endfor %}{% endif %}
+
 timeout = 10
 search_base = {{ ldap_base }}
 query_filter = (&(mail=%u@%d)(memberOf=cn=Local_mail,ou=MAIL_ACCESS,{{ ldap_base }}))

--- a/templates/etc/postfix/ldap/mailbox_maps.cf.j2
+++ b/templates/etc/postfix/ldap/mailbox_maps.cf.j2
@@ -1,5 +1,6 @@
 # LDAP to postfix link
-server_host = {{ ldap_uri }}
+server_host = {% if ldap_host is defined %}{% for item in ldap_host %}ldaps://{{ item }}:636/{% if not loop.last %} {% endif %}{% endfor %}{% endif %}
+
 timeout = 10
 search_base = {{ ldap_base }}
 # Filter                      account active         password don't expire     password had expired

--- a/templates/etc/postfix/ldap/national_in.cf.j2
+++ b/templates/etc/postfix/ldap/national_in.cf.j2
@@ -1,5 +1,6 @@
 # LDAP to postfix link
-server_host = {{ ldap_uri }}
+server_host = {% if ldap_host is defined %}{% for item in ldap_host %}ldaps://{{ item }}:636/{% if not loop.last %} {% endif %}{% endfor %}{% endif %}
+
 timeout = 10
 search_base = {{ ldap_base }}
 query_filter = (&(mail=%u@%d)(memberOf=cn=National_mail,ou=MAIL_ACCESS,{{ ldap_base }}))

--- a/templates/etc/postfix/ldap/national_out.cf.j2
+++ b/templates/etc/postfix/ldap/national_out.cf.j2
@@ -1,5 +1,6 @@
 # LDAP to postfix link
-server_host = {{ ldap_uri }}
+server_host = {% if ldap_host is defined %}{% for item in ldap_host %}ldaps://{{ item }}:636/{% if not loop.last %} {% endif %}{% endfor %}{% endif %}
+
 timeout = 10
 search_base = {{ ldap_base }}
 query_filter = (&(mail=%u@%d)(memberOf=cn=National_mail,ou=MAIL_ACCESS,{{ ldap_base }}))

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -220,6 +220,14 @@ smtpd_recipient_restrictions =
 {% if alwaysbcc is defined and alwaysbcc|bool %}
 # Security copy, destination mailbox must exist!
 always_bcc = {{ alwaysbcc }}
+{% endif %}
+
+{% if mailad_recipientbcc is defined %}
+# Security copy, destination mailbox must exist!
+recipient_bcc_maps = hash:/etc/postfix/recipient_bcc
+{% endif %}
+
+{% if ( mailad_recipientbcc is defined ) or ( alwaysbcc is defined and alwaysbcc|bool ) %}
 # disable the duplicated bcc
 receive_override_options = no_address_mappings
 {% endif %}

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -222,12 +222,12 @@ smtpd_recipient_restrictions =
 always_bcc = {{ alwaysbcc }}
 {% endif %}
 
-{% if mailad_recipientbcc is defined %}
+{% if recipientbcc is defined %}
 # Security copy, destination mailbox must exist!
 recipient_bcc_maps = hash:/etc/postfix/recipient_bcc
 {% endif %}
 
-{% if ( mailad_recipientbcc is defined ) or ( alwaysbcc is defined and alwaysbcc|bool ) %}
+{% if ( recipientbcc is defined ) or ( alwaysbcc is defined and alwaysbcc|bool ) %}
 # disable the duplicated bcc
 receive_override_options = no_address_mappings
 {% endif %}

--- a/templates/etc/postfix/recipient_bcc.j2
+++ b/templates/etc/postfix/recipient_bcc.j2
@@ -1,0 +1,5 @@
+{% if mailad_recipientbcc is defined %}
+{% for item in mailad_recipientbcc %}
+{{ item['to'] }} {{ item['bcc'] }}
+{% endfor %}
+{% endif %}

--- a/templates/etc/postfix/recipient_bcc.j2
+++ b/templates/etc/postfix/recipient_bcc.j2
@@ -1,5 +1,5 @@
-{% if mailad_recipientbcc is defined %}
-{% for item in mailad_recipientbcc %}
+{% if recipientbcc is defined %}
+{% for item in recipientbcc %}
 {{ item['to'] }} {{ item['bcc'] }}
 {% endfor %}
 {% endif %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,6 +6,8 @@ hostname_fqdn: mail.mailad.cu
 mailadmin: pavelmc@{{ domain_fqdn }}
 sysadmins:
 alwaysbcc:
+#recipientbcc:
+#  - { to: cuenta.to , bcc: cuenta.bcc }
 message_size: 2
 mailbox_size: 200M
 mynetworks: 10.42.1.0/24

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -20,8 +20,9 @@ mailbox_gid: "{{ mailbox_uid }}"
 mailbox_path: "/home/vmail"
 
 # LDAP credentials
-ldap_host: dc.mailad.cu
-ldap_uri: "ldaps://{{ ldap_host }}"
+ldap_host:
+  - dc.mailad.cu
+  - dc2.mailad.cu
 ldap_bind: cn=Linux,dc=Users,dc=mailad,dc=cu
 ldap_pass: "SuperSecret!"
 ldap_base: "ou=MAILAD,dc=mailad,dc=cu"


### PR DESCRIPTION
The three main changes for this pull request are:

1. Acommodate ADs in a list, in my TODO list for several months. It allows to have just one variable (instead of two) for the AD servers, and IMHO a list does better the task. Something to note is: Do we want to have a mix of secure and not secure ADs in the list, now is coded for all-secure, an easy solution is change the list to a format like this:
 - ldap://non.secure.domain
 - ldaps://secure.domain:636
I think we should prioritize secure servers as a best practice, let's remember that user accounts are crossing the network.

2. Permissions for folder /etc/postfix/ldap contents were readable by others. The have sensitive info, so I change the code to make it 0640. I suggest to move the creation of the folder to a separate task also so it can be 0750.

3. As noted some days ago, some recent Debian and Ubuntu deployments don't install /etc/ldap.conf (from package libldap-common). An easy solution is enforce the installation of package libldap-common. I recommend check the necessity of this in future versions. Question is: In future versions of Debian and Ubuntu ldap requires /etc/ldap.conf to make possible the use of ldaps://?

Best regards.