### PR TITLE
Several changes to implement redundancy of upstream relayhost(s) [issue #196]

### DIFF
--- a/tasks/postfix.yml
+++ b/tasks/postfix.yml
@@ -46,6 +46,10 @@
     mode: '0644'
   notify: postmap lista_negra
 
+- name: Gather package facts for postfix version check
+  ansible.builtin.package_facts:
+    manager: auto
+
 - name: "Apply templates to /etc/postfix folder items"
   template:
     src: "../templates/etc/postfix/{{ item }}.j2"

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -22,7 +22,24 @@ mydestination = $myhostname, localhost.$mydomain, localhost
 myorigin = $myhostname
 
 # relay host, blank for direct or IP/fqdn for hostname
+# use [square brackets] to avoid dns check of the ip
+# In Postfix >= 3.5 you can use several relays separated by comma or space
+# Check http://www.postfix.org/postconf.5.html#relayhost for further info
+{% if relayhost is defined %}
+{% if ansible_facts.packages['postfix'][0].version is version('3.5.0', '>=') %}
+relayhost = {% for item in relayhost %}{{ item }}{% if not loop.last %}, {% endif %}{% endfor %}
+{% else %}
+relayhost = {{ relayhost[0] }}
+{% endif %}
+{% else %}
 relayhost = {{ smarthost | default("") }}
+{% endif %}
+
+{% if smtp_fallback_relay is defined %}
+# host to use if relayhost fails
+# Check http://www.postfix.org/postconf.5.html#smtp_fallback_relay for further info
+smtp_fallback_relay = {% for item in smtp_fallback_relay %}{{ item }}{% if not loop.last %}, {% endif %}{% endfor %}
+{% endif %}
 
 # Only trusted servers/host's  networks here
 mynetworks = 127.0.0.0/8 {{ mynetworks }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -14,6 +14,14 @@ mynetworks: 10.42.1.0/24
 smarthost:
 everyone:
 national: ".cu" # end domain name, with the start dot, like ".edu.cu"
+# The following var is optional, define it if you have upstream relays
+# Several upstream relays can only be defined in Postfix >= 3.5
+#relayhost:
+#  - [ip] or fqdn
+# The following var is optional, define it if you have upstream relay(s)
+# to use ONLY in case of failure of the relayhost(s) defined.
+#smtp_fallback_relay:
+#  - [ip] or fqdn
 
 # mailbox settings
 mailbox_username: vmail


### PR DESCRIPTION
Change two vars to allow a list of servers (in relayhost and smtp_fallback_relay);
Include a task to check Postfix version and modify main.cf accordingly;
Change template of main.cf.